### PR TITLE
Fix(HotizontalList): fix badge import

### DIFF
--- a/packages/starlight-utils/components/HorizontalList.astro
+++ b/packages/starlight-utils/components/HorizontalList.astro
@@ -4,7 +4,7 @@
 import type { Props as StarlightProps } from "@astrojs/starlight/props";
 import type { SidebarData } from "./Sidebar.astro";
 import Sidebar from "@astrojs/starlight/components/Sidebar.astro";
-import { Badge } from "@astrojs/starlight/components";
+import Badge from "@astrojs/starlight/components/Badge.astro";
 
 interface Props {
   starlightProps: StarlightProps;


### PR DESCRIPTION
Build was erroring out due to the Badge component not being exported from @astrojs/starlight/components