### PR TITLE
feat: possibility to hide the Switcher

### DIFF
--- a/.changeset/rotten-eagles-remember.md
+++ b/.changeset/rotten-eagles-remember.md
@@ -1,0 +1,5 @@
+---
+"@lorenzo_lewis/starlight-utils": patch
+---
+
+Add `hidden` value for `switcherStyle`

--- a/.changeset/rotten-eagles-remember.md
+++ b/.changeset/rotten-eagles-remember.md
@@ -2,4 +2,4 @@
 "@lorenzo_lewis/starlight-utils": patch
 ---
 
-Add `hidden` value for `switcherStyle`
+Add `hidden` style for `switcherStyle`. This can be useful when combined with navigation links.

--- a/docs/src/content/docs/utilities/multi-sidebar.mdx
+++ b/docs/src/content/docs/utilities/multi-sidebar.mdx
@@ -51,11 +51,12 @@ export default defineConfig({
 
 ### `multiSidebar`
 
-**Type:** `boolean | { switcherStyle: "dropdown" | "horizontalList" } | undefined`
+**Type:** `boolean | { switcherStyle: "dropdown" | "horizontalList" | "hidden" } | undefined`
 
 - If `true`, the sidebar will be rendered with the `horizontalList` switcher style.
 - If no `multiSidebar` key is set, or if the value is `false` or `undefined`, then the default Starlight sidebar will be used.
 - Otherwise, the value specified in `switcherStyle` will be used.
+- The `hidden` style hides the sidebar switcher. This is useful if you are using [Nav Links](/utilities/nav-links/) and don't need a sidebar switcher.
 
 ## Migration
 

--- a/packages/starlight-utils/components/Sidebar.astro
+++ b/packages/starlight-utils/components/Sidebar.astro
@@ -80,6 +80,18 @@ if (
       {config.multiSidebar.switcherStyle === "horizontalList" && (
         <HorizontalList starlightProps={strippedProps} {multiSidebarData} />
       )}
+      {config.multiSidebar.switcherStyle === "hidden" && (
+        multiSidebarData.map(
+          ({ starlightProps, isCurrentSidebar, labelEntry }) => (
+            <div
+              hidden={!isCurrentSidebar}
+              data-starlight-multi-sidebar-label={labelEntry.label}
+            >
+              <Default {...starlightProps} />
+            </div>
+          )
+        )
+      )}
     </>
   ) : (
     <Default {...strippedProps} />

--- a/packages/starlight-utils/config.ts
+++ b/packages/starlight-utils/config.ts
@@ -5,7 +5,7 @@ const multiSidebarConfig = z
   .union([
     z.object({
       switcherStyle: z.union([
-        z.enum(["dropdown", "horizontalList"]).default("horizontalList"),
+        z.enum(["dropdown", "horizontalList", "hidden"]).default("horizontalList"),
         z.boolean(),
       ]),
     }),


### PR DESCRIPTION
Closes: #13

This PR adds the ability to hide the switcher by passing the `hidden` value to the `switcherStyle` configuration:

```js
starlightUtils({
  multiSidebar: {
    switcherStyle: "hidden",
  },
})
```

**Demo:**

https://github.com/lorenzolewis/starlight-utils/assets/29282228/b9342a39-0798-405a-ae45-9b0124c82203

